### PR TITLE
Fix ValueError exception on clean install, close #11

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -239,6 +239,7 @@ def shortCuts():
         index = index.split(",")
 
         for i in index:
+            if not i: continue
             try:
                 command = (paramGet
                            .GetGroup("Global shortcuts")
@@ -287,6 +288,7 @@ def shortCuts():
             index = index.split(",")
 
             for i in index:
+                if not i: continue
                 try:
                     command = (paramGet
                                .GetGroup(activeWB)


### PR DESCRIPTION
Check if group index is not empty.

Signed-off-by: Evgeniy Nepomniashchiy <gigarush@ya.ru>
